### PR TITLE
Append slash created presence issues; removed

### DIFF
--- a/cli/src/omnipresence/main.py
+++ b/cli/src/omnipresence/main.py
@@ -30,7 +30,7 @@ def post():
 
 def patch(data: dict = {}):
     response = requests.patch(
-        f"{os.getenv('API_URL')}:{os.getenv('API_PORT')}/v1/omnipresence/update/{data['pk']}",
+        f"{os.getenv('API_URL')}:{os.getenv('API_PORT')}/v1/omnipresence/update/{data['pk']}/",
         data = {
             "charname": data['charname'],
             "working_dir": os.getcwd(),


### PR DESCRIPTION
Remedies issue with Django's requirement of `APPEND_SLASH`; `omnipresence` was not updating due to the `PATCH` endpoint not matching slash semantics.