### PR TITLE
Build out client-side command structure and responses

### DIFF
--- a/cli/src/omnipresence/Who.py
+++ b/cli/src/omnipresence/Who.py
@@ -20,7 +20,7 @@ class Who:
                 "cwd": self.cwd
             }
         )
-        print(actives.json())
+        return actives.json()
 
 def cmd():
     Who()

--- a/cli/src/omnipresence/Who.py
+++ b/cli/src/omnipresence/Who.py
@@ -2,6 +2,9 @@ import os
 import sys
 import requests
 
+from rich.console import Console
+from rich.markdown import Markdown
+
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -12,6 +15,7 @@ class Who:
         self.cwd = os.getcwd()
         self.user = os.getenv('GITHUB_USER')
         user_list = self.__get_user_list()
+        self.__display_user_list(user_list)
 
     def __get_user_list(self):
         actives = requests.post(
@@ -21,6 +25,14 @@ class Who:
             }
         )
         return actives.json()
+
+    def __display_user_list(self, user_list: list = []):
+        console = Console()
+        if len(user_list) > 0:
+            users_fmt = [f"`🧙 {user['username']}`" for user in user_list]
+            markdown = f"> Users active in **{os.getcwd()}**: {', '.join(users_fmt)}"
+            console.print(Markdown(markdown))
+        console.print(Markdown(">  It appears that you are alone..."))
 
 def cmd():
     Who()

--- a/srv/endpoints/omnipresence/views.py
+++ b/srv/endpoints/omnipresence/views.py
@@ -55,7 +55,7 @@ class OmnipresenceActiveView(GenericAPIView):
     def post(self, request, *args, **kwargs):
         local_actives = OmnipresenceModel.objects.filter(
             working_dir = request.data.get('cwd')
-        )
+        ).values('charname')
         return HttpResponse(
             json.dumps(list(local_actives)),
             status = 200,


### PR DESCRIPTION
This `PR` throws Omnipresence changes to main in order to re-roll the containers to capture the new functionality.